### PR TITLE
Implement caching and event-based invalidation

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,8 @@ import { CqrsModule } from '@nestjs/cqrs';
 import { ClubUpdatedHandler } from './domain/handlers/club-updated.handler';
 import { GetAvailabilityHandler } from './domain/handlers/get-availability.handler';
 import { ALQUILA_TU_CANCHA_CLIENT } from './domain/ports/aquila-tu-cancha.client';
+import { InMemoryCacheService } from './infrastructure/cache/in-memory-cache.service';
+import { ClubIdToPlaceIdService } from './infrastructure/cache/club-id-to-place-id.service';
 import { HTTPAlquilaTuCanchaClient } from './infrastructure/clients/http-alquila-tu-cancha.client';
 import { EventsController } from './infrastructure/controllers/events.controller';
 import { SearchController } from './infrastructure/controllers/search.controller';
@@ -14,6 +16,8 @@ import { SearchController } from './infrastructure/controllers/search.controller
   imports: [HttpModule, CqrsModule, ConfigModule.forRoot()],
   controllers: [SearchController, EventsController],
   providers: [
+    InMemoryCacheService,
+    ClubIdToPlaceIdService,
     {
       provide: ALQUILA_TU_CANCHA_CLIENT,
       useClass: HTTPAlquilaTuCanchaClient,

--- a/src/domain/handlers/get-availability.handler.ts
+++ b/src/domain/handlers/get-availability.handler.ts
@@ -1,6 +1,7 @@
-import { Inject } from '@nestjs/common';
+import { Inject, Logger } from '@nestjs/common';
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
-
+import { InMemoryCacheService } from '../../infrastructure/cache/in-memory-cache.service';
+import { ClubIdToPlaceIdService } from '../../infrastructure/cache/club-id-to-place-id.service';
 import {
   ClubWithAvailability,
   GetAvailabilityQuery,
@@ -11,17 +12,37 @@ import {
 } from '../ports/aquila-tu-cancha.client';
 
 @QueryHandler(GetAvailabilityQuery)
-export class GetAvailabilityHandler
-  implements IQueryHandler<GetAvailabilityQuery>
-{
+export class GetAvailabilityHandler implements IQueryHandler<GetAvailabilityQuery> {
+  private readonly logger = new Logger(GetAvailabilityHandler.name);
+
   constructor(
     @Inject(ALQUILA_TU_CANCHA_CLIENT)
     private alquilaTuCanchaClient: AlquilaTuCanchaClient,
+    private cacheService: InMemoryCacheService,
+    private clubIdToPlaceIdService: ClubIdToPlaceIdService, // Inyectamos el nuevo servicio
   ) {}
 
   async execute(query: GetAvailabilityQuery): Promise<ClubWithAvailability[]> {
+    const dateStr = query.date.toISOString().slice(0, 10);
+    const cacheKey = `${query.placeId}-${dateStr}`;
+    this.logger.debug(`Executing GetAvailabilityHandler with cacheKey: ${cacheKey}`);
+
+    const cachedData = this.cacheService.get(cacheKey);
+    if (cachedData) {
+      this.logger.debug(`Cache hit for key: ${cacheKey}`);
+      return cachedData;
+    }
+
+    this.logger.debug(`Cache miss for key: ${cacheKey}, fetching from mock API...`);
+
     const clubs_with_availability: ClubWithAvailability[] = [];
     const clubs = await this.alquilaTuCanchaClient.getClubs(query.placeId);
+
+    // Guardar mapeo clubId → placeId
+    for (const club of clubs) {
+      this.clubIdToPlaceIdService.setMapping(club.id, query.placeId);
+    }
+
     for (const club of clubs) {
       const courts = await this.alquilaTuCanchaClient.getCourts(club.id);
       const courts_with_availability: ClubWithAvailability['courts'] = [];
@@ -41,6 +62,10 @@ export class GetAvailabilityHandler
         courts: courts_with_availability,
       });
     }
+
+    this.cacheService.set(cacheKey, clubs_with_availability);
+    this.logger.debug(`Data cached for key: ${cacheKey}`);
+
     return clubs_with_availability;
   }
 }

--- a/src/infrastructure/cache/club-id-to-place-id.service.ts
+++ b/src/infrastructure/cache/club-id-to-place-id.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ClubIdToPlaceIdService {
+  private clubToPlaceMap = new Map<number, string>();
+
+  setMapping(clubId: number, placeId: string) {
+    this.clubToPlaceMap.set(clubId, placeId);
+  }
+
+  getPlaceId(clubId: number): string | undefined {
+    return this.clubToPlaceMap.get(clubId);
+  }
+}

--- a/src/infrastructure/cache/in-memory-cache.service.ts
+++ b/src/infrastructure/cache/in-memory-cache.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+
+interface CacheEntry {
+  data: any;
+  timestamp: number;
+}
+
+@Injectable()
+export class InMemoryCacheService {
+  private cache = new Map<string, CacheEntry>();
+  private ttl = 60 * 1000; // TTL de 1 minuto, ajusta según necesidad
+
+  set(key: string, value: any) {
+    this.cache.set(key, { data: value, timestamp: Date.now() });
+  }
+
+  get(key: string): any | null {
+    const entry = this.cache.get(key);
+    if (!entry) {
+      return null;
+    }
+    // Verificar TTL
+    if (Date.now() - entry.timestamp > this.ttl) {
+      this.cache.delete(key);
+      return null;
+    }
+    return entry.data;
+  }
+
+  delete(key: string): void {
+    this.cache.delete(key);
+  }
+
+  clear() {
+    this.cache.clear();
+  }
+}

--- a/src/infrastructure/clients/http-alquila-tu-cancha.client.ts
+++ b/src/infrastructure/clients/http-alquila-tu-cancha.client.ts
@@ -7,41 +7,62 @@ import { Club } from '../../domain/model/club';
 import { Court } from '../../domain/model/court';
 import { Slot } from '../../domain/model/slot';
 import { AlquilaTuCanchaClient } from '../../domain/ports/aquila-tu-cancha.client';
+import { InMemoryCacheService } from '../cache/in-memory-cache.service';
 
 @Injectable()
 export class HTTPAlquilaTuCanchaClient implements AlquilaTuCanchaClient {
   private base_url: string;
-  constructor(private httpService: HttpService, config: ConfigService) {
+  constructor(
+    private httpService: HttpService,
+    config: ConfigService,
+    private cacheService: InMemoryCacheService,
+  ) {
     this.base_url = config.get<string>('ATC_BASE_URL', 'http://localhost:4000');
   }
 
   async getClubs(placeId: string): Promise<Club[]> {
-    return this.httpService.axiosRef
-      .get('clubs', {
-        baseURL: this.base_url,
-        params: { placeId },
-      })
-      .then((res) => res.data);
+    const cacheKey = `clubs-${placeId}`;
+    const cached = this.cacheService.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const data = await this.httpService.axiosRef.get('clubs', {
+      baseURL: this.base_url,
+      params: { placeId },
+    }).then((res) => res.data);
+
+    this.cacheService.set(cacheKey, data);
+    return data;
   }
 
-  getCourts(clubId: number): Promise<Court[]> {
-    return this.httpService.axiosRef
-      .get(`/clubs/${clubId}/courts`, {
-        baseURL: this.base_url,
-      })
-      .then((res) => res.data);
+  async getCourts(clubId: number): Promise<Court[]> {
+    const cacheKey = `courts-${clubId}`;
+    const cached = this.cacheService.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const data = await this.httpService.axiosRef.get(`/clubs/${clubId}/courts`, {
+      baseURL: this.base_url,
+    }).then((res) => res.data);
+
+    this.cacheService.set(cacheKey, data);
+    return data;
   }
 
-  getAvailableSlots(
+  async getAvailableSlots(
     clubId: number,
     courtId: number,
     date: Date,
   ): Promise<Slot[]> {
-    return this.httpService.axiosRef
-      .get(`/clubs/${clubId}/courts/${courtId}/slots`, {
-        baseURL: this.base_url,
-        params: { date: moment(date).format('YYYY-MM-DD') },
-      })
-      .then((res) => res.data);
+    // Podríamos cachear slots también, pero dado que cambian a menudo (por eventos), es menos útil
+    // a menos que implementes invalidaciones más precisas.
+    const dateStr = moment(date).format('YYYY-MM-DD');
+    const url = `/clubs/${clubId}/courts/${courtId}/slots`;
+    return this.httpService.axiosRef.get(url, {
+      baseURL: this.base_url,
+      params: { date: dateStr },
+    }).then((res) => res.data);
   }
 }

--- a/src/infrastructure/controllers/events.controller.ts
+++ b/src/infrastructure/controllers/events.controller.ts
@@ -2,11 +2,13 @@ import { Body, Controller, Post } from '@nestjs/common';
 import { EventBus } from '@nestjs/cqrs';
 import { UseZodGuard } from 'nestjs-zod';
 import { z } from 'nestjs-zod/z';
-
 import { ClubUpdatedEvent } from '../../domain/events/club-updated.event';
 import { CourtUpdatedEvent } from '../../domain/events/court-updated.event';
 import { SlotBookedEvent } from '../../domain/events/slot-booked.event';
 import { SlotAvailableEvent } from '../../domain/events/slot-cancelled.event';
+import { InMemoryCacheService } from '../cache/in-memory-cache.service';
+import { ClubIdToPlaceIdService } from '../cache/club-id-to-place-id.service';
+import * as moment from 'moment';
 
 const SlotSchema = z.object({
   price: z.number(),
@@ -43,11 +45,39 @@ export type ExternalEventDTO = z.infer<typeof ExternalEventSchema>;
 
 @Controller('events')
 export class EventsController {
-  constructor(private eventBus: EventBus) {}
+  constructor(
+    private eventBus: EventBus,
+    private cacheService: InMemoryCacheService,
+    private clubIdToPlaceIdService: ClubIdToPlaceIdService,
+  ) {}
 
   @Post()
   @UseZodGuard('body', ExternalEventSchema)
   async receiveEvent(@Body() externalEvent: ExternalEventDTO) {
+    // Antes invalidabas todo. Ahora serás más específico.
+    // Para booking_created o cancelled:
+    if (externalEvent.type === 'booking_created' || externalEvent.type === 'booking_cancelled') {
+      const placeId = this.clubIdToPlaceIdService.getPlaceId(externalEvent.clubId);
+      if (placeId) {
+        // Extraer la fecha del slot
+        const eventDate = moment(externalEvent.slot.datetime).format('YYYY-MM-DD');
+        const cacheKey = `${placeId}-${eventDate}`;
+        this.cacheService.delete(cacheKey);
+      }
+    } else if (externalEvent.type === 'club_updated' || externalEvent.type === 'court_updated') {
+      const placeId = this.clubIdToPlaceIdService.getPlaceId(externalEvent.clubId);
+      if (placeId) {
+        // Si afecta openhours (disponibilidad), invalida las entradas de esa semana.
+        // Como asunción: solo invalidamos 7 días (según el enunciado se consultan 7 días próximos)
+        // Esto es un ejemplo, puedes adaptarlo.
+        for (let i = 0; i < 7; i++) {
+          const dateStr = moment().add(i, 'days').format('YYYY-MM-DD');
+          const cacheKey = `${placeId}-${dateStr}`;
+          this.cacheService.delete(cacheKey);
+        }
+      }
+    }
+
     switch (externalEvent.type) {
       case 'booking_created':
         this.eventBus.publish(


### PR DESCRIPTION
1. Caché en memoria (InMemoryCacheService):

Se creó un servicio de caché simple en memoria (InMemoryCacheService) que permite almacenar los resultados de disponibilidad (clubs, canchas y horarios) durante un tiempo limitado (TTL).
De esta forma, las solicitudes repetidas para el mismo placeId y fecha devuelven resultados rápidamente sin volver a consultar a la API mock.

2. Lógica de caché en GetAvailabilityHandler:

Ahora, antes de llamar a la API mock, el handler verifica si existe información en caché.
Si hay un "cache hit", retorna inmediatamente y mejora el tiempo de respuesta.
Si hay un "cache miss", hace la llamada a la API mock, guarda el resultado en el caché y luego responde.
También se agregaron logs de depuración para verificar cuándo hay cache miss y cache hit.

3.Invalidación del caché basada en eventos (EventsController):

Originalmente, se invalidaba todo el caché ante cualquier evento, lo que impedía aprovechar el caché en ambientes con eventos frecuentes.
Ahora, se mantiene un mapeo clubId → placeId y se invalidan sólo las claves del caché afectadas por el evento.
Por ejemplo, si llega un evento booking_created que afecta un club específico y una fecha dada, se invalida únicamente la entrada correspondiente a ese placeId y esa fecha. No se borra todo el caché global.
Para eventos como club_updated que puedan afectar los horarios (ej. open_hours), se invalidan sólo las entradas relevantes. Esto mantiene el caché útil en el resto de las consultas.

4.Decisiones 

Se optó por un caché simple en memoria por facilidad de implementación y velocidad. En un entorno productivo, podría evaluarse usar Redis u otro sistema distribuido.
Los eventos pueden ocurrir con frecuencia, por lo que la invalidación selectiva del caché es clave para mantener la eficiencia.

5.Debido a la restricción de tiempo, no se alcanzaron a escribir tests adicionales para cubrir todos los casos de eventos complejos o fallos de la API mock.
Sin embargo, se priorizó la implementación del caché y la lógica de invalidación basada en eventos, así como las pruebas básicas de rendimiento y lógica del handler principal.
De tener más tiempo, se agregarían tests más completos, cubriendo escenarios de eventos simultáneos, fallas intermitentes de la mock y distintos placeId consultados en paralelo.
